### PR TITLE
fix: make self relative to root in full (#416)

### DIFF
--- a/src/fullsignalk.js
+++ b/src/fullsignalk.js
@@ -34,6 +34,7 @@ function FullSignalK(id, type, defaults) {
     this.root.vessels[id] = defaults && defaults.vessels && defaults.vessels.self ? defaults.vessels.self : {};
     this.self = this.root.vessels[id];
     signalkSchema.fillIdentity(this.root)
+    this.root.self = 'vessels.' + id
   }
   this.sources = {};
   this.root.sources = this.sources;

--- a/test/fullsignalk.js
+++ b/test/fullsignalk.js
@@ -178,4 +178,14 @@ describe('FullSignalK', function() {
     vessel.propulsion.engine1.temperature.should.have.property('$source', '1W.0316013faeff')
   })
 
+  it('MMSI self is set correctly in full tree', function() {
+    var fullSignalK = new FullSignalK('urn:mrn:imo:mmsi:276810000', null, {});
+    fullSignalK.retrieve().self.should.equal('vessels.urn:mrn:imo:mmsi:276810000')
+  })
+
+  it('UUID self is set correctly in full tree', function() {
+    var fullSignalK = new FullSignalK('urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d', null, {});
+    fullSignalK.retrieve().self.should.equal('vessels.urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d')
+  })
+
 })


### PR DESCRIPTION
Earlier fix to self being root relative was done only in
server and did not account for the case where you retrieve
the whole full document. Add tests for mmsi and uuid selfs.